### PR TITLE
ci(deps): security hardening of third-party GitHub Actions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,7 +8,7 @@ jobs:
   updateChangelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Update Changelog
@@ -18,7 +18,7 @@ jobs:
           ./git-chglog -o CHANGELOG.md v1.0.2..
           rm git-chglog
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           commit-message: update changelog
           title: Update CHANGELOG.md

--- a/.github/workflows/docs-gh-pages.yml
+++ b/.github/workflows/docs-gh-pages.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Customize theme and scss
         run: |
           cat > ./docs/_config.yml << EOF
@@ -92,12 +92,12 @@ jobs:
           cp ./docs/assets/css/style.scss ./docs/assets/main.scss
         shell: bash
       - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+        uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1.0.13
         with:
           source: ./docs
           destination: ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
 
   # Deployment job
   deploy:
@@ -110,4 +110,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -15,10 +15,10 @@ jobs:
       contents: read
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: "Configure Go"
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
 
       - name: "Build"
         run: go build -v ./...
@@ -32,14 +32,14 @@ jobs:
       contents: read
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: "Configure Go"
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           cache: false
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:
           args: --timeout 5m0s

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -24,7 +24,7 @@ jobs:
     if: (github.actor != 'dependabot[bot]')
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run Semgrep CI with debug
         run: |
@@ -42,7 +42,7 @@ jobs:
         if: always()
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
         with:
           sarif_file: semgrep.sarif
         if: success() && hashFiles('semgrep.sarif')

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -20,15 +20,15 @@ jobs:
       contents: read
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch || '' }}
 
       - name: "Configure Go"
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf
+        uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
         with:
           install-only: true
 
@@ -39,7 +39,7 @@ jobs:
         run: tar -cvf test-reg.tar ./test-reg
 
       - name: "Save build for testing"
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: test-build
           path: ./test-reg.tar
@@ -54,13 +54,13 @@ jobs:
       contents: read
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: "Configure Go"
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
 
       - name: "Download test release"
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: test-build
 
@@ -68,7 +68,7 @@ jobs:
         run: tar -xvf test-reg.tar
 
       - name: "Setup Terraform"
-        uses: autero1/action-terraform@v3.0.1
+        uses: autero1/action-terraform@43105c5ac1431a67287f012739dbbe6a163d6d95 # v3.0.1
         with:
           terraform-version: latest
 
@@ -88,13 +88,13 @@ jobs:
       contents: read
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: "Configure Go"
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
 
       - name: "Download test release"
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: test-build
 
@@ -102,7 +102,7 @@ jobs:
         run: tar -xvf test-reg.tar
 
       - name: "Setup Terraform"
-        uses: autero1/action-terraform@v3.0.1
+        uses: autero1/action-terraform@43105c5ac1431a67287f012739dbbe6a163d6d95 # v3.0.1
         with:
           terraform-version: latest
       - name: "Run Tests"


### PR DESCRIPTION
This PR will pin github actions to a commit SHA, and will help defend against supply-chain attacks.

This PR can be merged once your review process has concluded.

If you have any questions or concerns, please reach out to appsecteam@beyondtrust.com.

Jira: https://beyondtrust.atlassian.net/browse/SI-97

Thank you for helping BeyondTrust stay secure!
