### PR TITLE
chore: update workflows and go build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module terraform-provider-sra
 
-go 1.22.1
+go 1.23.0
+
 toolchain go1.24.1
 
 require (


### PR DESCRIPTION
This pull request updates the Go version used in the `terraform-provider-sra` project to align with the latest stable releases.

Version updates:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R4): Updated the Go version from `1.22.1` to `1.23.0` and added a toolchain specification for `go1.24.1`.